### PR TITLE
Update http-server tests to check url param parsing

### DIFF
--- a/http-server/gren.json
+++ b/http-server/gren.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "direct": {
             "gren-lang/core": "6.0.0",
-            "gren-lang/node": "5.0.0"
+            "gren-lang/node": "5.0.4"
         },
         "indirect": {
             "gren-lang/url": "5.0.0"

--- a/http-server/test/requests.mjs
+++ b/http-server/test/requests.mjs
@@ -35,9 +35,9 @@ describe("Requests", () => {
     assert.equal(res1.headers["content-type"], "text/html");
     assert.equal(res1.text, "You posted: some data");
 
-    const res2 = await request(url).put("/howdy");
+    const res2 = await request(url).put("/howdy?with=params");
     assert.equal(res2.headers["content-type"], "text/html");
-    assert.equal(res2.text, "Not found: PUT /howdy");
+    assert.equal(res2.text, "Not found: PUT http://localhost:3000/howdy?with=params");
   });
 
   // Can't actually test this because node:http doesn't support custom methods.


### PR DESCRIPTION
This fails on 5.0.3 but will pass when https://github.com/gren-lang/node/pull/30 is released. Will update this PR to include new node version when it's available.